### PR TITLE
Rewrite prismic image

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -10,18 +10,16 @@ export default {
   render(h, { props, data }) {
     const { url, alt, copyright } = props.field;
 
-     // See https://vuejs.org/v2/guide/render-function.html#Functional-Components
-    data.attrs = data.attrs || {};
-    data.attrs.src = url;
-    if (alt) {
-      data.attrs.alt = alt;
-    }
-    if (copyright) {
-      data.attrs.copyright = copyright;
-    }
     return h(
       'img',
-      data,
+      Object.assign(data, {
+        attrs: {
+          ...data.attrs,
+          src: url,
+          alt,
+          copyright
+        }
+      })
     );
   },
 };


### PR DESCRIPTION
Current implementation of `prismic-image` mutates `data` prop.

This PR assigns a clean `attrs` property to `data`.
The behaviour and use of the component should remain the same.
