### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Following the example above, let's write the associated template:
 ```html
 <template>
   <section>
-    <primsic-image :field="fields.logo" />
+    <prismic-image :field="fields.logo" />
     <prismic-rich-text :field="fields.title" />
     <prismic-rich-text :field="fields.somethingRich" />
   </section>


### PR DESCRIPTION
Found a typo in the documentation. This had me pull my hair out for a while, since I copypasted it into my project and didn't understand why it wasn't working :(