### PR TITLE
Include getSliceComponentProps in export for common

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,7 +3,7 @@ import Image from "./Image";
 import Link from "./Link";
 import RichText from "./RichText";
 import Text from "./Text";
-import { SliceZone } from "./SliceZone";
+import { SliceZone, getSliceComponentProps } from "./SliceZone";
 
 const NuxtLink = Link({ component: "nuxt-link" });
 const VueRouterLink = Link({ component: "router-link" });
@@ -15,6 +15,7 @@ const exp = {
 		RichText,
 		Text,
 		SliceZone,
+		getSliceComponentProps
 	},
 	nuxt: {
 		Link: NuxtLink,


### PR DESCRIPTION
## Types of changes

Include getSliceComponentProps in export for common

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

When unit testing Vue component with jest, getSliceComponentProps is not found in common.js file because it is not exported from. Therefore tests are failing.
Changement:
- getSliceComponentProps is now exported from common modules