### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/src/globalExtensions.ts
+++ b/src/globalExtensions.ts
@@ -1,6 +1,6 @@
 import type { PrismicPlugin } from "./types";
 
-declare module "@vue/runtime-core" {
+declare module "vue" {
 	export interface ComponentCustomProperties {
 		/**
 		 * `@prismicio/vue` plugin interface exposed on `this`.


### PR DESCRIPTION
## Types of changes

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

For a while, in the Vue ecosystem we've been augmenting @vue/runtime-core to add custom properties and more to vue. However, this inadvertently breaks the types for projects that augment vue - which is (now?) the officially recommended in the docs way to augment these interfaces (for example, [ComponentCustomProperties](https://vuejs.org/api/utility-types.html#componentcustomproperties), [GlobalComponents](https://vuejs.org/guide/extras/web-components.html#web-components-and-typescript) and [so on](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties)).

This means all libraries must update their code (or it will break the types of the libraries that augment vue instead).

[Here's an example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYygUwIYzQQTGOAXzgDMoIQ4ByANwFc0qAoJ5CAOwGd4N84BeFOiy58ACgSEAlCwD0suAAEYnALRoAHmDTIY6qOShwARhiOcAFhDoAbACYm0cGAE9tDjJ2owoDZmy54AH0MAC44djoQYzQjQV4wADoAkmAAc0S0mwhTGwAFcm1YYDRORNMoOQVlNU1tXX1DUggIOEtre0dnNzQPLyofP1YObjgg43DI6NiBOATkjlSMrJyMfMLYmBKykhaWOx0bMycQCDtbJ1o-RCY4OGB2bCgSDGQnAGEKSHY0R-e6bgUAoQIpbUo3O53XYQcKDNC3IhMQj7Q7HOCnc42S6KehoWS+R6gNCqNjoKgQ+6PWIvN5wT7gDi-GD-QEgYGg7YUu4VWG+eF3ZGEIA) of how the augmented types end up broken.

This PR is a small effort to ensure the ecosystem is consistent. For context, you can see that vue-router has https://github.com/vuejs/router/pull/2295, as well as https://github.com/nuxt/nuxt/pull/28542.

## Checklist:

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.
