### PR TITLE
refactor: introduce `getTableComponentProps` for consistency

### DIFF
--- a/src/PrismicTable/PrismicTableDefaultComponents.ts
+++ b/src/PrismicTable/PrismicTableDefaultComponents.ts
@@ -1,52 +1,42 @@
-import type {
-	TableField,
-	TableFieldBody,
-	TableFieldBodyRow,
-	TableFieldDataCell,
-	TableFieldHead,
-	TableFieldHeadRow,
-	TableFieldHeaderCell,
-} from "@prismicio/client"
 import { defineComponent, h } from "vue"
-import type { PropType } from "vue"
 
 import type { VueTableComponents } from "./types"
 
-export const defaultTableComponents: Required<
-	Pick<VueTableComponents, "table" | "thead" | "tbody" | "tr" | "th" | "td">
-> = {
+import * as getTableComponentProps from "./getTableComponentProps"
+
+export const defaultTableComponents: Required<VueTableComponents> = {
 	table: defineComponent({
-		props: { table: Object as PropType<TableField> },
+		props: getTableComponentProps.table(),
 		setup(props, { slots }) {
 			return () => h("table", slots.default ? slots.default() : [])
 		},
 	}),
 	thead: defineComponent({
-		props: { head: Object as PropType<TableFieldHead> },
+		props: getTableComponentProps.thead(),
 		setup(props, { slots }) {
 			return () => h("thead", slots.default ? slots.default() : [])
 		},
 	}),
 	tbody: defineComponent({
-		props: { body: Object as PropType<TableFieldBody> },
+		props: getTableComponentProps.tbody(),
 		setup(props, { slots }) {
 			return () => h("tbody", slots.default ? slots.default() : [])
 		},
 	}),
 	tr: defineComponent({
-		props: { row: Object as PropType<TableFieldHeadRow | TableFieldBodyRow> },
+		props: getTableComponentProps.tr(),
 		setup(props, { slots }) {
 			return () => h("tr", slots.default ? slots.default() : [])
 		},
 	}),
 	th: defineComponent({
-		props: { cell: Object as PropType<TableFieldHeaderCell> },
+		props: getTableComponentProps.th(),
 		setup(props, { slots }) {
 			return () => h("th", slots.default ? slots.default() : [])
 		},
 	}),
 	td: defineComponent({
-		props: { cell: Object as PropType<TableFieldDataCell> },
+		props: getTableComponentProps.td(),
 		setup(props, { slots }) {
 			return () => h("td", slots.default ? slots.default() : [])
 		},

--- a/src/PrismicTable/getTableComponentProps.ts
+++ b/src/PrismicTable/getTableComponentProps.ts
@@ -1,0 +1,142 @@
+import type {
+	TableField,
+	TableFieldBody,
+	TableFieldBodyRow,
+	TableFieldDataCell,
+	TableFieldHead,
+	TableFieldHeadRow,
+	TableFieldHeaderCell,
+} from "@prismicio/client"
+import type { PropType } from "vue"
+
+/**
+ * Gets native Vue props for a component rendering `table` elements from a
+ * Prismic table field with `<PrismicTable />`.
+ *
+ * Props are: `["table"]`
+ *
+ * @example
+ *
+ * ```javascript
+ * // Defining a new rich text component
+ * import { getTableComponentProps } from "@prismicio/vue"
+ *
+ * defineProps(getTableComponentProps.table())
+ * ```
+ */
+export const table = (): {
+	table: { type: PropType<TableField<"filled">>; required: true }
+} => ({
+	table: { type: Object as PropType<TableField<"filled">>, required: true },
+})
+
+/**
+ * Gets native Vue props for a component rendering `thead` elements from a
+ * Prismic table field with `<PrismicTable />`.
+ *
+ * Props are: `["head"]`
+ *
+ * @example
+ *
+ * ```javascript
+ * // Defining a new rich text component
+ * import { getTableComponentProps } from "@prismicio/vue"
+ *
+ * defineProps(getTableComponentProps.thead())
+ * ```
+ */
+export const thead = (): {
+	head: { type: PropType<TableFieldHead>; required: true }
+} => ({
+	head: { type: Object as PropType<TableFieldHead>, required: true },
+})
+
+/**
+ * Gets native Vue props for a component rendering `tbody` elements from a
+ * Prismic table field with `<PrismicTable />`.
+ *
+ * Props are: `["body"]`
+ *
+ * @example
+ *
+ * ```javascript
+ * // Defining a new rich text component
+ * import { getTableComponentProps } from "@prismicio/vue"
+ *
+ * defineProps(getTableComponentProps.body())
+ * ```
+ */
+export const tbody = (): {
+	body: { type: PropType<TableFieldBody>; required: true }
+} => ({
+	body: { type: Object as PropType<TableFieldBody>, required: true },
+})
+
+/**
+ * Gets native Vue props for a component rendering `tr` elements from a Prismic
+ * table field with `<PrismicTable />`.
+ *
+ * Props are: `["row"]`
+ *
+ * @example
+ *
+ * ```javascript
+ * // Defining a new rich text component
+ * import { getTableComponentProps } from "@prismicio/vue"
+ *
+ * defineProps(getTableComponentProps.tr())
+ * ```
+ */
+export const tr = (): {
+	row: {
+		type: PropType<TableFieldHeadRow | TableFieldBodyRow>
+		required: true
+	}
+} => ({
+	row: {
+		type: Object as PropType<TableFieldHeadRow | TableFieldBodyRow>,
+		required: true,
+	},
+})
+
+/**
+ * Gets native Vue props for a component rendering `th` elements from a Prismic
+ * table field with `<PrismicTable />`.
+ *
+ * Props are: `["cell"]`
+ *
+ * @example
+ *
+ * ```javascript
+ * // Defining a new rich text component
+ * import { getTableComponentProps } from "@prismicio/vue"
+ *
+ * defineProps(getTableComponentProps.th())
+ * ```
+ */
+export const th = (): {
+	cell: { type: PropType<TableFieldHeaderCell>; required: true }
+} => ({
+	cell: { type: Object as PropType<TableFieldHeaderCell>, required: true },
+})
+
+/**
+ * Gets native Vue props for a component rendering `td` elements from a Prismic
+ * table field with `<PrismicTable />`.
+ *
+ * Props are: `["cell"]`
+ *
+ * @example
+ *
+ * ```javascript
+ * // Defining a new rich text component
+ * import { getTableComponentProps } from "@prismicio/vue"
+ *
+ * defineProps(getTableComponentProps.td())
+ * ```
+ */
+export const td = (): {
+	cell: { type: PropType<TableFieldDataCell>; required: true }
+} => ({
+	cell: { type: Object as PropType<TableFieldDataCell>, required: true },
+})

--- a/src/PrismicTable/index.ts
+++ b/src/PrismicTable/index.ts
@@ -1,0 +1,1 @@
+export * as getTableComponentProps from "./getTableComponentProps"

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export type {
 	RichTextComponentProps,
 } from "./PrismicRichText"
 
+export { getTableComponentProps } from "./PrismicTable"
+
 export {
 	TODOSliceComponent,
 	defineSliceZoneComponents,

--- a/test/components-PrismicTable.test.ts
+++ b/test/components-PrismicTable.test.ts
@@ -6,7 +6,11 @@ import { defineComponent, markRaw } from "vue"
 
 import { WrapperComponent } from "./__fixtures__/WrapperComponent"
 
-import { PrismicTable } from "../src"
+import {
+	PrismicTable,
+	getRichTextComponentProps,
+	getTableComponentProps,
+} from "../src"
 
 const filledTableField: TableField = {
 	head: {
@@ -159,74 +163,80 @@ it("renders custom table elements", () => {
 			components: {
 				table: markRaw(
 					defineComponent({
-						template: `<div class="table"><slot></slot></div>`,
+						template: /* html */ `<div class="table"><slot></slot></div>`,
+						props: getTableComponentProps.table(),
 					}),
 				),
 				thead: markRaw(
 					defineComponent({
-						template: `<div class="thead"><slot></slot></div>`,
+						template: /* html */ `<div class="thead"><slot></slot></div>`,
+						props: getTableComponentProps.thead(),
 					}),
 				),
 				tbody: markRaw(
 					defineComponent({
-						template: `<div class="tbody"><slot></slot></div>`,
+						template: /* html */ `<div class="tbody"><slot></slot></div>`,
+						props: getTableComponentProps.tbody(),
 					}),
 				),
 				tr: markRaw(
 					defineComponent({
-						template: `<div class="tr"><slot></slot></div>`,
+						template: /* html */ `<div class="tr"><slot></slot></div>`,
+						props: getTableComponentProps.tr(),
 					}),
 				),
 				th: markRaw(
 					defineComponent({
-						template: `<div class="th"><slot></slot></div>`,
+						template: /* html */ `<div class="th"><slot></slot></div>`,
+						props: getTableComponentProps.th(),
 					}),
 				),
 				td: markRaw(
 					defineComponent({
-						template: `<div class="td"><slot></slot></div>`,
+						template: /* html */ `<div class="td"><slot></slot></div>`,
+						props: getTableComponentProps.td(),
 					}),
 				),
 			},
 		},
 	})
 
-	expect(output.html()).toBe(`<div class="table" table="[object Object]">
-  <div class="thead" head="[object Object]">
-    <div class="tr" row="[object Object]">
-      <div class="th" cell="[object Object]">
+	expect(output.html()).toBe(`<div class="table">
+  <div class="thead">
+    <div class="tr">
+      <div class="th">
         <p>
           <!--v-if-->Method
         </p>
       </div>
-      <div class="th" cell="[object Object]">
+      <div class="th">
         <p>
           <!--v-if-->Usage
         </p>
       </div>
     </div>
   </div>
-  <div class="tbody" body="[object Object]">
-    <div class="tr" row="[object Object]">
-      <div class="th" cell="[object Object]">
+  <div class="tbody">
+    <div class="tr">
+      <div class="th">
         <p>
           <!--v-if-->GET
         </p>
       </div>
-      <div class="td" cell="[object Object]">
+      <div class="td">
         <p>
           <!--v-if-->For <strong><!--v-if-->basic retrieval</strong>
           <!--v-if--> of information…
         </p>
       </div>
     </div>
-    <div class="tr" row="[object Object]">
-      <div class="th" cell="[object Object]">
+    <div class="tr">
+      <div class="th">
         <p>
           <!--v-if-->DELETE
         </p>
       </div>
-      <div class="td" cell="[object Object]">
+      <div class="td">
         <p>
           <!--v-if-->To <em><!--v-if-->dest</em>
           <!--v-if-->roy a resource and remove…
@@ -244,28 +254,30 @@ it("renders custom table cell content", () => {
 			components: {
 				table: markRaw(
 					defineComponent({
-						template: `<table class="table"><slot></slot></table>`,
+						template: /* html */ `<table class="table"><slot></slot></table>`,
+						props: getTableComponentProps.table(),
 					}),
 				),
 				paragraph: markRaw(
 					defineComponent({
-						template: `<p class="paragraph"><slot></slot></p>`,
+						template: /* html */ `<p class="paragraph"><slot></slot></p>`,
+						props: getRichTextComponentProps("paragraph"),
 					}),
 				),
 			},
 		},
 	})
 
-	expect(output.html()).toBe(`<table class="table" table="[object Object]">
+	expect(output.html()).toBe(`<table class="table">
   <thead>
     <tr>
       <th>
-        <p class="paragraph" node="[object Object]">
+        <p class="paragraph">
           <!--v-if-->Method
         </p>
       </th>
       <th>
-        <p class="paragraph" node="[object Object]">
+        <p class="paragraph">
           <!--v-if-->Usage
         </p>
       </th>
@@ -274,12 +286,12 @@ it("renders custom table cell content", () => {
   <tbody>
     <tr>
       <th>
-        <p class="paragraph" node="[object Object]">
+        <p class="paragraph">
           <!--v-if-->GET
         </p>
       </th>
       <td>
-        <p class="paragraph" node="[object Object]">
+        <p class="paragraph">
           <!--v-if-->For <strong><!--v-if-->basic retrieval</strong>
           <!--v-if--> of information…
         </p>
@@ -287,12 +299,12 @@ it("renders custom table cell content", () => {
     </tr>
     <tr>
       <th>
-        <p class="paragraph" node="[object Object]">
+        <p class="paragraph">
           <!--v-if-->DELETE
         </p>
       </th>
       <td>
-        <p class="paragraph" node="[object Object]">
+        <p class="paragraph">
           <!--v-if-->To <em><!--v-if-->dest</em>
           <!--v-if-->roy a resource and remove…
         </p>


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR edits #76 with the following changes:

- Introduce a new `getTableComponentProps` set of helpers to define table component props for Vue.js.
- Updates the tests accordingly to use these new helpers consistently, removing the unwanted `table="[object Object]"`occurrence.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
