### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"author": "Prismic <contact@prismic.io> (https://prismic.io)",
 	"repository": {
 		"type": "git",
-		"url": "ssh://git@github.com/prismicio/prismic-vue.git"
+		"url": "git+https://github.com/prismicio/prismic-vue.git"
 	},
 	"files": [
 		"./dist",


### PR DESCRIPTION
## Summary

- update the package repository metadata from an SSH GitHub URL to a public HTTPS Git URL
- make the npm package metadata easier for package registries and tooling to consume without GitHub SSH access

## Validation

- `node -e` metadata assertion
- `git diff --check`
- `pnpm --package=npm@11.13.0 dlx npm ci --ignore-scripts`
- `pnpm --package=npm@11.13.0 dlx npm run lint`
- `pnpm --package=npm@11.13.0 dlx npm run types`
- `pnpm --package=npm@11.13.0 dlx npm run unit` (8 files / 80 tests passed)
- `pnpm --package=npm@11.13.0 dlx npm run build`
- `pnpm --package=npm@11.13.0 dlx npm pack --dry-run`

Note: `npm ci --ignore-scripts` reports existing dependency audit findings; this PR does not change dependencies or lockfiles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change with no effect on build output, dependencies, or application behavior.
> 
> **Overview**
> **Package metadata only:** `repository.url` in `package.json` changes from `ssh://git@github.com/prismicio/prismic-vue.git` to `git+https://github.com/prismicio/prismic-vue.git`.
> 
> No runtime, API, or dependency changes—this aligns npm’s published metadata with a public HTTPS clone URL for consumers and tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671010ee131e48e3be71d06bc754a03887f87ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->